### PR TITLE
Emit SSE error frame after connect window

### DIFF
--- a/chat/src/provider/anthropic.rs
+++ b/chat/src/provider/anthropic.rs
@@ -38,6 +38,40 @@ const EVENT_TX_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 /// flow through `AppError` as proper HTTP 4xx with the upstream status code.
 const CONNECT_ERROR_WINDOW: Duration = Duration::from_secs(15);
 
+/// Maps a Bedrock `ConverseStreamError` to an Anthropic error `type` and
+/// extracts the human-readable upstream message. Default arm falls back to
+/// `api_error` so newly-introduced Bedrock variants never panic.
+fn classify_bedrock_error(err: &SdkError<ConverseStreamError>) -> (&'static str, String) {
+    let msg = err
+        .as_service_error()
+        .and_then(|e| e.meta().message())
+        .map(String::from)
+        .unwrap_or_else(|| err.to_string());
+
+    let kind = match err.as_service_error() {
+        Some(ConverseStreamError::ValidationException(_)) => "invalid_request_error",
+        Some(ConverseStreamError::ThrottlingException(_)) => "rate_limit_error",
+        Some(ConverseStreamError::AccessDeniedException(_)) => "permission_error",
+        Some(ConverseStreamError::ServiceUnavailableException(_)) => "overloaded_error",
+        Some(ConverseStreamError::ModelTimeoutException(_)) => "timeout_error",
+        Some(ConverseStreamError::ModelStreamErrorException(_)) => "api_error",
+        Some(ConverseStreamError::InternalServerException(_)) => "api_error",
+        _ => "api_error",
+    };
+    (kind, msg)
+}
+
+/// Builds a single-line Anthropic-style SSE error frame. Used when the HTTP
+/// status has already been committed as 200 and we can no longer surface the
+/// failure as 4xx via `AppError`.
+fn anthropic_error_event(kind: &str, message: &str) -> anyhow::Result<Event> {
+    let payload = serde_json::json!({
+        "type": "error",
+        "error": { "type": kind, "message": message }
+    });
+    Ok(Event::default().event("error").data(payload.to_string()))
+}
+
 /// Sends a ping SSE event. Returns false if the consumer is gone or stuck.
 async fn send_ping(event_tx: &mpsc::Sender<anyhow::Result<Event>>) -> bool {
     info!("Sending ping event");
@@ -92,9 +126,11 @@ async fn process_bedrock_stream_events(
                     }
                     Ok(None) => break,
                     Err(e) => {
-                        let _ = timeout(EVENT_TX_SEND_TIMEOUT, event_tx
-                            .send(Err(anyhow!("Stream receive error: {}", e))))
-                            .await;
+                        let event = anthropic_error_event(
+                            "api_error",
+                            &format!("Stream receive error: {e}"),
+                        );
+                        let _ = timeout(EVENT_TX_SEND_TIMEOUT, event_tx.send(event)).await;
                         break;
                     }
                 }
@@ -368,6 +404,12 @@ impl V1MessagesProvider for BedrockV1MessagesProvider {
                                         "Bedrock API error on retry after connect window: {:?}",
                                         e
                                     );
+                                    let (kind, msg) = classify_bedrock_error(&e);
+                                    let _ = timeout(
+                                        EVENT_TX_SEND_TIMEOUT,
+                                        event_tx.send(anthropic_error_event(kind, &msg)),
+                                    )
+                                    .await;
                                 }
                             }
                         });
@@ -404,6 +446,12 @@ impl V1MessagesProvider for BedrockV1MessagesProvider {
                         }
                         Err(e) => {
                             error!("Bedrock API error after connect window: {:?}", e);
+                            let (kind, msg) = classify_bedrock_error(&e);
+                            let _ = timeout(
+                                EVENT_TX_SEND_TIMEOUT,
+                                event_tx.send(anthropic_error_event(kind, &msg)),
+                            )
+                            .await;
                         }
                     }
                 });


### PR DESCRIPTION
## Summary

Closes #50.

PR #49 widened `CONNECT_ERROR_WINDOW` to 15s, which catches almost every fast Bedrock error and routes it through `AppError` → 4xx. But the leak itself — *"an error cannot be sent after `200` is sent"* (Henry, May 28) — is still reachable for any error arriving after the window, plus every mid-stream `recv()` error.

This PR adds the SSE error-frame helper agreed in the May 28 Slack thread and wires it into the three remaining leak sites in `chat/src/provider/anthropic.rs`:

- mid-stream `recv()` error (`:94–99`)
- slow-connect spawn `Err(e)` (`:405–407`)
- retry slow-connect spawn `Err(e)` — thinking-block-blanked path (`:366–371`)

## Behavior

| Case | Before this PR (post #49) | After |
|---|---|---|
| Slow context overflow (>15s) | 200 + empty body | 200 + SSE error · "prompt is too long…" |
| Throttling / overloaded / timeout (slow tail) | 200 + empty body | 200 + SSE error |
| Mid-stream `modelStreamError` | 200 + malformed | 200 + SSE error · clean termination |
| Successful generation, fast TTFB | unchanged | unchanged |
| Successful generation, 60s+ TTFB | unchanged | unchanged |

## Notes

- `classify_bedrock_error` default arm falls back to `api_error` so newly-introduced `ConverseStreamError` variants (the enum is `#[non_exhaustive]`) won't break the build.
- Did not include `ServiceQuotaExceededException` — not present in the SDK version pinned by this workspace; the default arm handles it as `api_error`.
- 15s race + ping fallback intact — required for 60s+ TTFB Opus 4.7 successes (corporate proxies / CDNs / SDK read timeouts cut idle connections without keep-alive bytes).

## Test plan

- [x] `cargo check -p chat` — clean
- [x] `cargo test -p chat --lib` — 15 passed, 0 failed
- [x] `cargo build --tests` — clean
- [ ] Manually exercise long-generation request to confirm pings continue to fire (60s+ TTFB scenario)
- [ ] Run `v1_messages_context_window_exceeded_returns_http_400` with `cargo test -- --ignored` against real Bedrock to confirm 400 path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)