### PR TITLE
Fix two `200 + malformed body` leaks in /v1/messages SSE stream

### DIFF
--- a/anthropic-response/src/stream.rs
+++ b/anthropic-response/src/stream.rs
@@ -15,6 +15,8 @@ pub struct EventConverter {
     model: String,
     previous_converse_stream_output_type_is_message_start_or_content_block_stop: bool,
     stop_reason: Option<String>,
+    started: bool,
+    terminated: bool,
     usage_callback: Arc<dyn Fn(&TokenUsage) + Send + Sync>,
 }
 
@@ -29,6 +31,8 @@ impl EventConverter {
             model,
             previous_converse_stream_output_type_is_message_start_or_content_block_stop: false,
             stop_reason: None,
+            started: false,
+            terminated: false,
             usage_callback,
         }
     }
@@ -41,6 +45,7 @@ impl EventConverter {
             ConverseStreamOutput::MessageStart(_) => {
                 self.previous_converse_stream_output_type_is_message_start_or_content_block_stop =
                     true;
+                self.started = true;
                 Some(vec![(
                     "message_start",
                     Event::message_start_builder()
@@ -155,6 +160,7 @@ impl EventConverter {
                 if let Some(ref usage) = event.usage {
                     (self.usage_callback)(usage);
                 }
+                self.terminated = true;
 
                 Some(vec![
                     (
@@ -193,5 +199,116 @@ impl EventConverter {
             }
             _ => None,
         }
+    }
+
+    /// Synthesizes the terminating `message_delta` + `message_stop` SSE pair
+    /// when the upstream Bedrock stream ended without a `Metadata` event
+    /// (e.g. an intermediate gateway truncated the tail). Idempotent and a
+    /// no-op once the converter has already emitted the terminator via the
+    /// `Metadata` arm, or if `MessageStart` was never seen.
+    ///
+    /// Usage is reported as zero — the upstream `usage_callback` never fires
+    /// when `Metadata` is missing, but the client at least gets a well-formed
+    /// stream end with the `stop_reason` recorded from `MessageStop`.
+    pub fn finalize(&mut self) -> Option<Vec<(&'static str, Event)>> {
+        if !self.started || self.terminated {
+            return None;
+        }
+        self.terminated = true;
+        Some(vec![
+            (
+                "message_delta",
+                Event::message_delta_builder()
+                    .delta(MessageDeltaContent {
+                        stop_reason: self.stop_reason.clone(),
+                        stop_sequence: None,
+                    })
+                    .usage(UsageDelta::builder().build())
+                    .build(),
+            ),
+            ("message_stop", Event::message_stop()),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_bedrockruntime::types::{
+        ConversationRole, ConverseStreamMetadataEvent, MessageStartEvent, MessageStopEvent,
+    };
+
+    fn converter() -> EventConverter {
+        EventConverter::new(
+            "msg_test".to_string(),
+            "model_test".to_string(),
+            Arc::new(|_| {}),
+        )
+    }
+
+    fn message_start() -> ConverseStreamOutput {
+        ConverseStreamOutput::MessageStart(
+            MessageStartEvent::builder()
+                .role(ConversationRole::Assistant)
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn message_stop() -> ConverseStreamOutput {
+        ConverseStreamOutput::MessageStop(
+            MessageStopEvent::builder()
+                .stop_reason(StopReason::EndTurn)
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn metadata() -> ConverseStreamOutput {
+        ConverseStreamOutput::Metadata(ConverseStreamMetadataEvent::builder().build())
+    }
+
+    #[test]
+    fn finalize_emits_terminator_when_metadata_missing() {
+        let mut conv = converter();
+        let _ = conv.convert(&message_start());
+        let _ = conv.convert(&message_stop());
+
+        let events = conv.finalize().expect("finalize should emit a terminator");
+
+        let names: Vec<_> = events.iter().map(|(name, _)| *name).collect();
+        assert_eq!(names, vec!["message_delta", "message_stop"]);
+
+        let (_, delta) = &events[0];
+        let json = serde_json::to_value(delta).unwrap();
+        assert_eq!(json["delta"]["stop_reason"], "end_turn");
+        assert_eq!(json["usage"]["input_tokens"], 0);
+        assert_eq!(json["usage"]["output_tokens"], 0);
+    }
+
+    #[test]
+    fn finalize_is_noop_after_metadata_already_terminated_stream() {
+        let mut conv = converter();
+        let _ = conv.convert(&message_start());
+        let _ = conv.convert(&message_stop());
+        let _ = conv.convert(&metadata());
+
+        assert!(conv.finalize().is_none());
+    }
+
+    #[test]
+    fn finalize_is_noop_before_message_start() {
+        let mut conv = converter();
+        assert!(conv.finalize().is_none());
+    }
+
+    #[test]
+    fn finalize_is_idempotent() {
+        let mut conv = converter();
+        let _ = conv.convert(&message_start());
+        let _ = conv.convert(&message_stop());
+
+        assert!(conv.finalize().is_some());
+        assert!(conv.finalize().is_none());
     }
 }

--- a/chat/src/provider/anthropic.rs
+++ b/chat/src/provider/anthropic.rs
@@ -4,7 +4,6 @@ use anthropic_request::{
     get_additional_model_request_fields,
 };
 use anthropic_response::EventConverter;
-use anyhow::anyhow;
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::{
     Client,
@@ -98,7 +97,7 @@ async fn process_bedrock_stream_events(
 ) {
     let id = format!("msg_{}", Uuid::new_v4());
     let mut event_converter = EventConverter::new(id, model, usage_callback);
-    loop {
+    'outer: loop {
         tokio::select! {
             biased;
             result = stream.recv() => {
@@ -106,9 +105,16 @@ async fn process_bedrock_stream_events(
                     Ok(Some(output)) => {
                         if let Some(events) = event_converter.convert(&output) {
                             for (event_name, event) in events {
+                                let mut serde_failed = false;
                                 let sse_event = match serde_json::to_string(&event) {
                                     Ok(json) => Ok(Event::default().event(event_name).data(json)),
-                                    Err(e) => Err(anyhow!("Failed to serialize event: {}", e)),
+                                    Err(e) => {
+                                        serde_failed = true;
+                                        anthropic_error_event(
+                                            "api_error",
+                                            &format!("Failed to serialize event: {e}"),
+                                        )
+                                    }
                                 };
                                 match timeout(EVENT_TX_SEND_TIMEOUT, event_tx.send(sse_event)).await {
                                     Ok(Ok(())) => {}
@@ -121,17 +127,39 @@ async fn process_bedrock_stream_events(
                                         return;
                                     }
                                 }
+                                if serde_failed {
+                                    error!("Event serialization failed; terminating stream");
+                                    break 'outer;
+                                }
                             }
                         }
                     }
-                    Ok(None) => break,
+                    Ok(None) => {
+                        // Bedrock closed the stream cleanly. If `Metadata` never arrived
+                        // (e.g. a gateway truncated the tail), synthesize the terminating
+                        // pair so the client sees a well-formed end instead of EOF
+                        // mid-protocol.
+                        if let Some(events) = event_converter.finalize() {
+                            for (event_name, event) in events {
+                                let sse_event = match serde_json::to_string(&event) {
+                                    Ok(json) => Ok(Event::default().event(event_name).data(json)),
+                                    Err(e) => anthropic_error_event(
+                                        "api_error",
+                                        &format!("Failed to serialize event: {e}"),
+                                    ),
+                                };
+                                let _ = timeout(EVENT_TX_SEND_TIMEOUT, event_tx.send(sse_event)).await;
+                            }
+                        }
+                        break 'outer;
+                    }
                     Err(e) => {
                         let event = anthropic_error_event(
                             "api_error",
                             &format!("Stream receive error: {e}"),
                         );
                         let _ = timeout(EVENT_TX_SEND_TIMEOUT, event_tx.send(event)).await;
-                        break;
+                        break 'outer;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add `EventConverter::finalize()` to synthesize a terminating `message_delta` + `message_stop` SSE pair when Bedrock closes the stream without a `Metadata` event (e.g. gateway truncation), preventing the "API returned an empty or malformed response (HTTP 200)" symptom from reaching the client
- Route serde-serialize failures in `process_bedrock_stream_events` through `anthropic_error_event` instead of dropping the stream as `Err(anyhow!())` (axum's `Sse` would silently terminate on `Err` without writing a frame), so failures now surface as a parseable Anthropic-shaped SSE error frame
- Preserve the rich-usage happy path: `Metadata` continues to emit `message_delta` with full token counts; `finalize()` only fires on truncation and reports usage as zero

Closes #53

## Test plan

- [x] `cargo test --workspace` — all 151 unit tests pass, including 4 new tests in `anthropic-response/src/stream.rs`:
  - `finalize_emits_terminator_when_metadata_missing`
  - `finalize_is_noop_after_metadata_already_terminated_stream`
  - `finalize_is_noop_before_message_start`
  - `finalize_is_idempotent`
- [x] `cargo clippy --workspace --all-targets` produces no new warnings
- [ ] Manual verification: trigger a Bedrock stream that ends without `Metadata` (e.g. via the existing injection harness in `gateway-proxy-rs`) and confirm the client renders a clean stream end instead of "API returned an empty or malformed response"
- [ ] Manual verification: confirm the 60s+ TTFB streaming path is unchanged — pings still fire, successful long generations still complete, `message_delta` carries the real usage numbers when `Metadata` arrives normally
- [ ] Existing e2e regression test `v1_messages_context_window_exceeded_returns_http_400` still passes (ignored by default; run with `--include-ignored`)